### PR TITLE
Adding CookieManager property to ID3 server CookieOptions class.

### DIFF
--- a/source/Core/Configuration/AppBuilderExtensions/ConfigureCookieAuthenticationExtension.cs
+++ b/source/Core/Configuration/AppBuilderExtensions/ConfigureCookieAuthenticationExtension.cs
@@ -49,6 +49,7 @@ namespace Owin
                 CookieSecure = GetCookieSecure(options.SecureMode),
                 TicketDataFormat = new TicketDataFormat(new DataProtectorAdapter(dataProtector, options.Prefix + Constants.PrimaryAuthenticationType)),
                 SessionStore = GetSessionStore(options.SessionStoreProvider),
+                CookieManager = options.CookieManagar,
                 Provider = new CookieAuthenticationProvider
                 {
                     OnValidateIdentity = async cookieCtx =>
@@ -72,6 +73,7 @@ namespace Owin
                 ExpireTimeSpan = Constants.ExternalCookieTimeSpan,
                 SlidingExpiration = false,
                 CookieSecure = GetCookieSecure(options.SecureMode),
+                CookieManager = options.CookieManagar,
                 TicketDataFormat = new TicketDataFormat(new DataProtectorAdapter(dataProtector, options.Prefix + Constants.ExternalAuthenticationType))
             };
             app.UseCookieAuthentication(external);
@@ -84,6 +86,7 @@ namespace Owin
                 ExpireTimeSpan = options.ExpireTimeSpan,
                 SlidingExpiration = options.SlidingExpiration,
                 CookieSecure = GetCookieSecure(options.SecureMode),
+                CookieManager = options.CookieManagar,
                 TicketDataFormat = new TicketDataFormat(new DataProtectorAdapter(dataProtector, options.Prefix + Constants.PartialSignInAuthenticationType))
             };
             app.UseCookieAuthentication(partial);

--- a/source/Core/Configuration/CookieOptions.cs
+++ b/source/Core/Configuration/CookieOptions.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using Microsoft.Owin.Infrastructure;
 using System;
 
 namespace IdentityServer3.Core.Configuration
@@ -107,7 +108,13 @@ namespace IdentityServer3.Core.Configuration
         /// </summary>
         public IAuthenticationSessionStoreProvider SessionStoreProvider { get; set; }
 
-
+        /// <summary>
+        /// Allows consuming application to set CookieManager.
+        /// This is done to solve Cookie specific issue as mentioned in following links:
+        /// https://github.com/IdentityServer/IdentityServer3/issues/2884
+        /// https://github.com/aspnet/AspNetKatana/wiki/System.Web-response-cookie-integration-issues
+        /// </summary>
+        public ICookieManager CookieManagar { get; set; }
 
     }
 }

--- a/source/Core/Core.csproj
+++ b/source/Core/Core.csproj
@@ -622,6 +622,14 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>CD $(SolutionDir)
+CD packages\ILMerge.2.14.1208\tools\
+MD $(TargetDir)\ILMerged
+ILMerge.exe $(TargetDir)IdentityServer3.dll $(TargetDir)Autofac.dll $(TargetDir)Microsoft.Owin.StaticFiles.dll $(TargetDir)Microsoft.Owin.FileSystems.dll $(TargetDir)Autofac.Integration.WebApi.dll $(TargetDir)System.Web.Http.Tracing.dll /out:$(TargetDir)\ILMerged\IdentityServer3.dll
+
+</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
This CookieManager can be set from applicaton consuming ID3 server.
This is to resolve issue https://github.com/IdentityServer/IdentityServer3/issues/2884
based on workaround mentioned in:
https://github.com/aspnet/AspNetKatana/wiki/System.Web-response-cookie-integration-issues